### PR TITLE
sort extensions in popup menu

### DIFF
--- a/extensions@abteil.org/extension.js
+++ b/extensions@abteil.org/extension.js
@@ -56,7 +56,15 @@ const ExtensionsManager = new Lang.Class({
     },
     _refresh: function() {
         this.menu.removeAll();
-        let uuids = Object.keys(ExtensionUtils.extensions)
+        let uuids = Object.keys(ExtensionUtils.extensions);
+
+        uuids.sort(function(a, b) {
+            a = ExtensionUtils.extensions[a].metadata.name;
+            b = ExtensionUtils.extensions[b].metadata.name;
+
+            return a < b ? -1 : (a > b ? 1 : 0);
+        });
+
         uuids.forEach(Lang.bind(this, function(uuid) {
             let item = new PopupExtensionItem(uuid);
             this.menu.addMenuItem(item);


### PR DESCRIPTION
Thanks, I love this extension.  But the first thing I noticed was that the extensions weren't sorted alphabetically, so I just added a call to sort the `uuids` variable by the extension name prior to being added to the popup window. Also, on line 59 of extension.js, there was no semicolon.  Let me know if you like and thanks again for this extension!