### PR TITLE
Version update

### DIFF
--- a/extensions@abteil.org/metadata.json
+++ b/extensions@abteil.org/metadata.json
@@ -5,6 +5,6 @@
 	"description": "Enable/disable easily gnome shell extensions from a menu in the top panel. Also allows to edit the settings of the extensions. Feedback welcome!",
 	"settings-schema": "org.gnome.shell.extensions.extensions",
 	"shell-version": [
-		"3.20", "3.22"
+		"3.20", "3.22", "3.24"
 	]
 }


### PR DESCRIPTION
Recently updated my Gnome version to 3.24 and got very confused when this extension was disabled. Changed the version list and it works fine.

This is probably worth looking at since 3.24 seems to be the version distributed with Fedora now.