### PR TITLE
fix setting button can't acess prefs page

### DIFF
--- a/extensions@abteil.org/popupExtensionItem.js
+++ b/extensions@abteil.org/popupExtensionItem.js
@@ -28,7 +28,7 @@ class PopupExtensionItem extends PopupMenu.PopupBaseMenuItem {
 
             let settingsButton = new St.Button({ child: settingsIcon });
             settingsButton.connect('clicked', Lang.bind(this, function() {
-                Util.spawn(["gnome-shell-extension-prefs", uuid]);
+                Util.spawn(["gnome-extensions", "prefs", uuid]);
                 this._getTopMenu().close()
             }));
             hbox.add_child(settingsButton);


### PR DESCRIPTION
gnome-shell-extension-prefs is known as Extensions from 3.36